### PR TITLE
fixing drm headers location

### DIFF
--- a/misc/pixel_format.c
+++ b/misc/pixel_format.c
@@ -1,4 +1,4 @@
-#include <drm_fourcc.h>
+#include <drm/drm_fourcc.h>
 #include "render/pixel_format.h"
 
 static const struct wlr_pixel_format_info pixel_format_info[] = {

--- a/render.c
+++ b/render.c
@@ -10,7 +10,7 @@
 #include <pixman-1/pixman.h>
 #include <vulkan/vulkan.h>
 #include <math.h>
-#include <drm_fourcc.h>
+#include <drm/drm_fourcc.h>
 
 #include <wlr/backend.h>
 #include <wlr/render/allocator.h>
@@ -267,4 +267,3 @@ bool draw_frame(struct wlr_output *output, struct wl_list *surfaces, int cursor_
 }
 
 // End my stuff
-

--- a/vkwc.c
+++ b/vkwc.c
@@ -11,7 +11,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include <pixman-1/pixman.h>
 #include <vulkan/vulkan.h>
-#include <drm_fourcc.h>
+#include <drm/drm_fourcc.h>
 
 #define CGLM_CLIPSPACE_INCLUDE_ALL
 #include <cglm/cglm.h>
@@ -330,7 +330,7 @@ void check_uv(struct Server *server, int cursor_x, int cursor_y,
 	// Checks the UV texture to see what's under the cursor. Returns the surface under the cursor and the x
 	// and y relative to this surface.
 	// Returns NULL to surface if there is no surface under the cursor.
-	
+
 	// There are multiple render buffers, so we have to find the right one. I do this just by checking whether
 	// the render buffer's dimensions match those of the first output, which isn't a great way but works for now.
 	struct wlr_vk_renderer *renderer = (struct wlr_vk_renderer *) server->renderer;

--- a/vulkan/pixel_format.c
+++ b/vulkan/pixel_format.c
@@ -1,4 +1,4 @@
-#include <drm_fourcc.h>
+#include <drm/drm_fourcc.h>
 #include <stdlib.h>
 #include <vulkan/vulkan.h>
 #include <wlr/util/log.h>
@@ -322,4 +322,3 @@ struct wlr_vk_format_modifier_props *vulkan_format_props_find_modifier(
 
 	return NULL;
 }
-

--- a/vulkan/renderer.c
+++ b/vulkan/renderer.c
@@ -7,7 +7,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <drm_fourcc.h>
+#include <drm/drm_fourcc.h>
 #include <vulkan/vulkan.h>
 #include <wlr/render/interface.h>
 #include <wlr/types/wlr_drm.h>
@@ -617,7 +617,7 @@ static struct wlr_vk_render_buffer *create_render_buffer(
 	// Create attachment to write UV coordinates into
 	create_image(renderer, UV_FORMAT, VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT,
 		dmabuf.width, dmabuf.height,
-		VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT 
+		VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
  		| VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, &buffer->uv);
 
 	VkMemoryRequirements uv_mem_reqs;


### PR DESCRIPTION
when you run build.sh, it gives some errors where files such as drm.h doesn't exists and they are located on /usr/include/drm. i suggest to update README.md too for telling the user to install [cglm](https://github.com/recp/cglm) and [wlroots](https://github.com/swaywm/wlroots) and wayland/others packages